### PR TITLE
feat: deploy prod profile by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ jobs:
           LIGHTDASH_PROJECT: ${{ secrets.LIGHTDASH_PROJECT }}          
           LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}          
 
-        run: lightdash deploy --project-dir . --profiles-dir .
+        run: lightdash deploy --project-dir . --profiles-dir . --profile prod || lightdash deploy --project-dir . --profiles-dir .


### PR DESCRIPTION
 run deploy … --profile prod by default, then if it errors, we run it without the flag

![Screenshot from 2022-09-22 16-30-19](https://user-images.githubusercontent.com/1983672/191775434-63977ef4-2505-4fa6-bfc0-84fe74e093f0.png)
