### PR TITLE
feat: support google credentials

### DIFF
--- a/start-preview.yml
+++ b/start-preview.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           python-version: "3.7.x"
 
+      - name: Exports Google credentials
+        id: create-json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "credentials.json"
+          json: ${{ secrets.GOOGLE_CREDENTIALS }}
+
       - name: Get lightdash version 
         uses: sergeysova/jq-action@v2
         id: version 
@@ -41,7 +48,8 @@ jobs:
         env:
           LIGHTDASH_API_KEY: ${{ secrets.LIGHTDASH_API_KEY }}          
           LIGHTDASH_PROJECT: ${{ secrets.LIGHTDASH_PROJECT }}          
-          LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}          
+          LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}      
+          GOOGLE_APPLICATION_CREDENTIALS: './credentials.json'    
 
         run:  lightdash start-preview --project-dir . --profiles-dir . --name ${GITHUB_REF##*/}
 

--- a/start-preview.yml
+++ b/start-preview.yml
@@ -16,12 +16,15 @@ jobs:
         with:
           python-version: "3.7.x"
 
-      - name: Exports Google credentials
+      - name: Copy Google credentials file
+        env: 
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        if: "${{ env.GOOGLE_CREDENTIALS != '' }}"
         id: create-json
         uses: jsdaniell/create-json@1.1.2
         with:
-          name: "credentials.json"
-          json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          name: "googlecredentials.json"
+          json: ${{ env.GOOGLE_CREDENTIALS }}
 
       - name: Get lightdash version 
         uses: sergeysova/jq-action@v2
@@ -49,7 +52,7 @@ jobs:
           LIGHTDASH_API_KEY: ${{ secrets.LIGHTDASH_API_KEY }}          
           LIGHTDASH_PROJECT: ${{ secrets.LIGHTDASH_PROJECT }}          
           LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}      
-          GOOGLE_APPLICATION_CREDENTIALS: './credentials.json'    
+          GOOGLE_APPLICATION_CREDENTIALS: './googlecredentials.json'
 
         run:  lightdash start-preview --project-dir . --profiles-dir . --name ${GITHUB_REF##*/}
 


### PR DESCRIPTION
I added a new step to copy crednetials from secret to file, This step does not fail if the secret does not exist, so it is compatible with non oauth profiles too. 

New documenattion required

```
Create new `GOOGLE_CREDENTIALS` secret with your credentials.json config file

It looks like this: 

{
  "type": "service_account",
  "project_id": "jaffle_shop",
  "private_key_id": "12345",
  "private_key": "-----BEGIN PRIVATE KEY----- ... -----END PRIVATE KEY-----\n",
  "client_email": "jaffle_shop@jaffle_shop.iam.gserviceaccount.com",
  "client_id": "12345",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://oauth2.googleapis.com/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/jaffle_shop"
}


```

Note: 
This feature will only work on cli version `0.266.0` or higher, as I added support for `service` credentials. If you are testing this, yo'll have to remove the "install same version" command and force @latest