### PR TITLE
adjust stop-preview name

### DIFF
--- a/close-preview.yml
+++ b/close-preview.yml
@@ -30,6 +30,6 @@ jobs:
           LIGHTDASH_PROJECT: ${{ secrets.LIGHTDASH_PROJECT }}          
           LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}          
 
-        run:  lightdash stop-preview --name ${GITHUB_HEAD_REF}
+        run:  lightdash stop-preview --name ${GITHUB_HEAD_REF##*/}
 
 


### PR DESCRIPTION
adjust name to match up with what preview is named in start-preview.yml by only looking after the `/` 
ex: if a branch named `cooper/lightdash-preview` is pushed, a preview named `lightdash-preview` is created, however upon closing the PR the Lightdash CLI stop preview step looks for a preview named `cooper/lightdash-preview` which doesn't exist so nothing is done which can cause a build up of preview environments - with this edit the stop preview will look for a preview named `lightdash-preview`