### PR TITLE
fix: add explicit permissions to get the PR

### DIFF
--- a/start-preview.yml
+++ b/start-preview.yml
@@ -11,7 +11,9 @@ env:
 jobs:
   preview:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1

--- a/start-preview.yml
+++ b/start-preview.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1


### PR DESCRIPTION
Closes: [#9608](https://github.com/lightdash/lightdash/issues/9608)
- When running on `public` repository we're able to get the PR number
- When running on `private` repository, we need to add explicit permissions to `contents` and  `pull-requests` otherwise we get this error

![image](https://github.com/lightdash/cli-actions/assets/22939015/83ad035c-742f-4ab9-bae6-d3668eeb40f5)

`pull-requests` needs to be `write` because of `marocchino/sticky-pull-request-comment`: https://github.com/marocchino/sticky-pull-request-comment?tab=readme-ov-file#error-resource-not-accessible-by-integration
