### PR TITLE
Fetch Lightdash version without jq-action

### DIFF
--- a/compile.yml
+++ b/compile.yml
@@ -38,12 +38,12 @@ jobs:
         run: echo "PROJECT_DIR=$(find . -name "dbt_project.yml"  | sed  's/dbt_project.yml//g')" >> $GITHUB_ENV
 
       - name: Get lightdash version
-        uses: sergeysova/jq-action@v2
         id: version
         env:
           LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}
-        with:
-          cmd: curl -s "${LIGHTDASH_URL}/api/v1/health" | jq -r '.results.version'
+        run: |
+          VERSION=$(curl -s "${LIGHTDASH_URL}/api/v1/health" | jq -r '.results.version')
+          echo "value=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Copy profiles.yml
         env:


### PR DESCRIPTION
Replaced jq-action usage with a direct command to fetch the Lightdash version and set it as an output variable. I see these lines were here 4 years ago, when jq was not widely available on all ubuntu machines.