### PR TITLE
ci: pin Node 24 in CLI workflow templates

### DIFF
--- a/close-preview.yml
+++ b/close-preview.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: '24'
 
       - name: Get lightdash version 
         uses: sergeysova/jq-action@v2

--- a/compile.yml
+++ b/compile.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: '24'
       - uses: actions/setup-python@v1
         with:
           python-version: "3.10.x"

--- a/deploy.yml
+++ b/deploy.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: '24'
       - uses: actions/setup-python@v1
         with:
           python-version: "3.10.x"

--- a/lightdash-validate.yml
+++ b/lightdash-validate.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: '24'
       - uses: actions/setup-python@v1
         with:
           python-version: "3.10.x"

--- a/refresh.yml
+++ b/refresh.yml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
       - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: '24'
 
       - name: Get lightdash version
         uses: sergeysova/jq-action@v2

--- a/start-preview.yml
+++ b/start-preview.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: '24'
       - uses: actions/setup-python@v1
         with:
           python-version: "3.10.x"


### PR DESCRIPTION
## Summary

The Lightdash CLI now requires **Node.js 24** (Node 20 reached end-of-life in April 2026, and the project has standardised on the current Active LTS).

These reusable workflow templates didn't pin a Node version on their `setup-node` steps, so they ran the CLI on whatever Node the runner shipped by default. GitHub's hosted default is moving to Node 24, but that's not guaranteed across all runners/versions — so this makes it explicit.

## Change

Add `node-version: '24'` to the `actions/setup-node` step in every workflow:

- `compile.yml`
- `deploy.yml`
- `start-preview.yml`
- `close-preview.yml`
- `refresh.yml`
- `lightdash-validate.yml`

`setup-node@v3.4.1` resolves Node versions from the live manifest, so it installs Node 24 fine without bumping the action itself.

## Notes

- These templates are referenced across the Lightdash docs, so pinning here keeps the documented CI path on the CLI's supported runtime.
- Out of scope (worth a follow-up): `actions/setup-node` is pinned to a fairly old `v3.4.1` and could be bumped to `v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)